### PR TITLE
adafruit_itertools_extra: Fix import

### DIFF
--- a/adafruit_itertools/adafruit_itertools_extras.py
+++ b/adafruit_itertools/adafruit_itertools_extras.py
@@ -74,7 +74,7 @@ Based on code from the offical Python documentation.
   https://github.com/adafruit/circuitpython/releases
 """
 
-#pylint:disable=invalid-name,deprecated-lambda,keyword-arg-before-vararg
+#pylint:disable=invalid-name,deprecated-lambda,keyword-arg-before-vararg,relative-beyond-top-level
 
 from . import adafruit_itertools as it
 

--- a/adafruit_itertools/adafruit_itertools_extras.py
+++ b/adafruit_itertools/adafruit_itertools_extras.py
@@ -76,7 +76,7 @@ Based on code from the offical Python documentation.
 
 #pylint:disable=invalid-name,deprecated-lambda,keyword-arg-before-vararg
 
-import adafruit_itertools as it
+from . import adafruit_itertools as it
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Itertools.git"


### PR DESCRIPTION
The import statement incorrectly referred to the package, not the submodule, leading to the reported traceback

Testing performed: the user's testcase,
```
>>> from adafruit_itertools.adafruit_itertools import count
>>> from adafruit_itertools.adafruit_itertools_extras import take
>>> take(1, count(1, 5))
[1]
```

Closes: #3