### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_itertools/__init__.py
+++ b/adafruit_itertools/__init__.py
@@ -263,8 +263,6 @@ class groupby:
     # [list(g) for k, g in groupby('AAAABBBCCD')] --> AAAA BBB CC D
 
     def __init__(self, iterable, key=None):
-        if key is None:
-            key = lambda x: x
         self.keyfunc = key if key is not None else lambda x: x
         self.it = iter(iterable)
         self.tgtkey = self.currkey = self.currvalue = object()

--- a/adafruit_itertools/__init__.py
+++ b/adafruit_itertools/__init__.py
@@ -265,7 +265,7 @@ class groupby:
     def __init__(self, iterable, key=None):
         if key is None:
             key = lambda x: x
-        self.keyfunc = key
+        self.keyfunc = key if key is not None else lambda x: x
         self.it = iter(iterable)
         self.tgtkey = self.currkey = self.currvalue = object()
 


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
************* Module adafruit_itertools
Error: adafruit_itertools/__init__.py:267:18: C3001: Lambda expression assigned to a variable. Define a function using the "def" keyword instead. (unnecessary-lambda-assignment)
```